### PR TITLE
Update .gitignore to refine ignored files and directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ Thumbs.db
 .actrc*
 
 __pycache__/
+/.vs/skills-getting-started-with-github-copilot.slnx/FileContentIndex
+/.vs/skills-getting-started-with-github-copilot/CopilotIndices/18.0.925.419
+/.vs


### PR DESCRIPTION
Update .gitignore to refine ignored files and directories

Refined the `.gitignore` file to ensure proper exclusion of:
- Python cache directories (`__pycache__/`).
- Visual Studio-specific files and directories (`.vs/`).
Added entries for specific Visual Studio-related paths to prevent environment-specific files from being tracked.